### PR TITLE
run: add Procfile to run on toolforge

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+run-cron: ./erex_yomi.rb

--- a/README.md
+++ b/README.md
@@ -5,9 +5,17 @@ Generate and e-mail a daily selection of the Hebrew Wikipedia to a(n external) l
 
 The template names are all hard-coded out of sheer laziness, but it should be trivial to adapt to other Mediawiki-based sites, and you're very welcome to do so.
 
-It is designed to be run via cron(1).  Here's a sample crontab line:
+It is designed to be run via toolforge jobs.  Here's a sample way to run it:
 
-   0 19 */2 * * /home/abartov/.rvm/rubies/ruby-2.0.0-p247/bin/ruby /home/abartov/erex_yomi/erex_yomi.rb
+
+    # build it
+    toolforge build start https://github.com/abartov/erex_yomi
+    # schedule the cron
+    toolforge jobs run \
+            --schedule '0 19 */2 * *' \
+            --command run-cron \
+            --image tool-erex-yomi/tool-erex-yomi:latest \
+            --filelog
 
 Author
 ======

--- a/erex_yomi.rb
+++ b/erex_yomi.rb
@@ -1,4 +1,4 @@
-#!ruby 
+#!/usr/bin/env ruby
 #
 # Erex Yomi e-mails a featured article, picture, and Today in History from the Hebrew Wikipedia to subscribers, via a mailing list
 # 


### PR DESCRIPTION
This allows running on the newer toolforge platform using:
```
toolforge jobs run \
    --schedule '0 19 */2 * *' \
    --command run-cron \
    --image tool-erex-yomi/tool-erex-yomi:latest \
    --filelog
```